### PR TITLE
There was a variable name mish-mash

### DIFF
--- a/app.js
+++ b/app.js
@@ -46,14 +46,14 @@ $(function() {
     $group.hide();
 
     var auth;
-    if (token) authorization = 'Bearer ' + token;
-    else authorization = 'Client-ID ' + clientId;
+    if (token) auth = 'Bearer ' + token;
+    else auth = 'Client-ID ' + clientId;
 
     $.ajax({
       url: 'https://api.imgur.com/3/image',
       method: 'POST',
       headers: {
-        Authorization: authorization,
+        Authorization: auth,
         Accept: 'application/json'
       },
       data: {


### PR DESCRIPTION
You declare auth, then use authorization. Does not hurt functionality, but causes undeclared global variable.
