### PR TITLE
$.ajax uses `type` not `method` to specify request method

### DIFF
--- a/app.js
+++ b/app.js
@@ -51,7 +51,7 @@ $(function() {
 
     $.ajax({
       url: 'https://api.imgur.com/3/image',
-      method: 'POST',
+      type: 'POST',
       headers: {
         Authorization: auth,
         Accept: 'application/json'


### PR DESCRIPTION
Took me a while to figure this out, since I'm not jQuery user.
