### PR TITLE
improve browser compatability with camera loading

### DIFF
--- a/gifie.js
+++ b/gifie.js
@@ -24,7 +24,15 @@ gifie = (function() {
     navigator.getUserMedia({
       video: true
     }, function(stream) {
-      video.src = window.URL.createObjectURL(stream);
+      if (navigator.mozGetUserMedia) {
+        video.mozSrcObject = stream;
+      } else {
+        try {
+          video.src = (window.URL || window.webkitURL).createObjectURL(stream);
+        } catch(e) {
+          video.srcObject = stream;
+        }
+      }
       trigger('prepare');
     }, function(err) {
       trigger('prepare', err);


### PR DESCRIPTION
This app was breaking for me on Mac OS X in Chrome. This update does some extra checks for setting up the video with the webcam stream.

I have this working in another project: https://github.com/mrcoles/videoloop/blob/master/src/js/index.js#L114